### PR TITLE
Remove the system limitation and check the generic solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ To install this module manually:
 4.  Click 'Install' and wait for installation to complete
 5.  Don't forget to enable the module in game using the "Manage Module" button
 
+# System Integration
+
+|            	| dnd5e 	| pf2e 	| wfrp4e 	| sw5e 	| swade 	|
+|------------	|-------	|------	|--------	|--------	|
+| Settings   	| ✓     	| ✓    	| ✓      	| ✓      	| ✓      	|
+| Logic      	| ✗     	| ✗    	| ✗      	| ✗      	| ✗      	|
+
+
+One of main principles of this module is being [**System Agnostic**](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/wiki#1-completely-system-agnostic). There is however, way of integrating systems.
+
+Basic settings initialization (like setting default persisting properties for dnd5e) I will allow to be built-in this module. These can, however, be defined from the System's side.
+
 # Usage
 
 Right click on items in sidebar, or use buttons on Item Sheet's header to Mystify an item. It will create new apparently blank item.
@@ -335,16 +347,6 @@ If `true`, user can see and press `Peek` Header Button to open Original Item she
 #### `canMystify`
 If `true`, user can see and press `Mystify` Header Button. 
 
-# System Integration
-
-|            	| dnd5e 	| pf2e 	| wfrp4e 	| swade 	|
-|------------	|-------	|------	|--------	|--------	|
-| Settings   	| ✓     	| ✓    	| ✓      	| ✓      	|
-| Logic      	| ✗     	| ✗    	| ✗      	| ✗      	|
-
-One of main principles of this module is being [**System Agnostic**](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/wiki#1-completely-system-agnostic). There is however, way of integrating systems.
-
-Basic settings initialization (like setting default persisting properties for dnd5e) I will allow to be built-in this module. These can, however, be defined from the System's side.
 
 #### What about logic? Skill Checks for Identification?
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.4
+
+- New design pattern for multissytem integration
+
 ## v0.4.2
 
 - Update typescript to 9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forien-unidentified-items",
-  "version": "0.4.2",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forien-unidentified-items",
-      "version": "0.4.2",
+      "version": "0.5.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "build": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "forien-unidentified-items",
-  "version": "0.4.2",
   "description": "Provides system agnostic solution to handle unidentified items and their identification.",
-  "version": "0.4.2",
+  "version": "0.5.4",
   "main": "init.js",
   "scripts": {
     "publish": "gulp publish --update",

--- a/src/module.json
+++ b/src/module.json
@@ -2,8 +2,7 @@
   "name": "forien-unidentified-items",
   "title": "Forien's Unidentified Items",
   "description": "Provides system agnostic solution to handle unidentified items and their identification.",
-  "version": "0.4.2",
-  "author": "Matheus Clemente — mclemente#5524, Forien — Forien#2130, p4535992",
+  "version": "0.5.4",
   "authors": [
     {
       "name": "Forien",
@@ -61,15 +60,14 @@
       "path": "./lang/ja.json"
     }
   ],
-  "system": ["dnd5e", "pf2e", "swade", "sw5e", "wfrp4e"],
   "esmodules": ["./init.js"],
   "styles": ["./styles/style.css"],
   "scripts": [],
   "url": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items",
   "manifest": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/releases/latest/download/module.json",
-  "download": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/releases/download/v0.4.2/module.zip",
-  "readme": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/blob/v0.4.2/README.md",
-  "changelog": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/blob/v0.4.2/changelog.md",
+  "download": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/releases/download/v0.5.4/module.zip",
+  "readme": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/blob/v0.5.4/README.md",
+  "changelog": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/blob/v0.5.4/changelog.md",
   "bugs": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/issues",
   "wiki": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/wiki",
   "allowBugReporter": true,

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -299,38 +299,6 @@ export async function checkSystem() {
   return applyDefaultSettings();
 }
 
-// /**
-//  * Registers settings menu (button)
-//  */
-// function registerSettingMenus() {
-//   game.settings.registerMenu(CONSTANTS.MODULE_NAME, 'defaultIcons', {
-//     name: `${CONSTANTS.MODULE_NAME}.Settings.defaultIcons.name`,
-//     label: `${CONSTANTS.MODULE_NAME}.Settings.defaultIcons.label`,
-//     hint: `${CONSTANTS.MODULE_NAME}.Settings.defaultIcons.hint`,
-//     icon: 'fas fa-image',
-//     type: DefaultIcons,
-//     restricted: true,
-//   });
-
-//   game.settings.registerMenu(CONSTANTS.MODULE_NAME, 'itemProperties', {
-//     name: `${CONSTANTS.MODULE_NAME}.Settings.itemProperties.name`,
-//     label: `${CONSTANTS.MODULE_NAME}.Settings.itemProperties.label`,
-//     hint: `${CONSTANTS.MODULE_NAME}.Settings.itemProperties.hint`,
-//     icon: 'fas fa-cogs',
-//     type: ItemProperties,
-//     restricted: true,
-//   });
-
-//   game.settings.register(CONSTANTS.MODULE_NAME, 'removeLabelButtonsSheetHeader', {
-//     name: i18n(`${CONSTANTS.MODULE_NAME}.Settings.removeLabelButtonsSheetHeader.name`),
-//     hint: i18n(`${CONSTANTS.MODULE_NAME}.Settings.removeLabelButtonsSheetHeader.hint`),
-//     scope: 'world',
-//     config: true,
-//     type: Boolean,
-//     default: true,
-//   });
-// }
-
 /**
  * Checks if options exist, if not, orders their initialization
  */
@@ -367,7 +335,7 @@ function initializeDefaultIcons() {
   Hooks.call(`${CONSTANTS.MODULE_NAME}:onInitializeDefaultIcons`, icons);
   settings = mergeObject(settings, icons);
   di.saveSettings(settings);
-  log(` Initialized default item icons.`);
+  log(`Initialized default item icons.`);
   ui.notifications?.info(game.i18n.localize(`${CONSTANTS.MODULE_NAME}.Notifications.defaultIconsInitialized`), {
     permanent: true,
   });
@@ -410,48 +378,3 @@ function initializeItemProperties() {
   });
 }
 
-// /**
-//  * Function responsible for out-of-the-box integration with systems.
-//  *
-//  * Function must return object of key-value entries:
-//  *   - key   - item type
-//  *   - value - objects of of key-value pairs of flattened
-//  *             data names and boolean values
-//  *
-//  * Example of "defaults" object:
-//  *   {
-//  *     weapon: {
-//  *       "description": true,
-//  *       "attack.damage": true
-//  *     },
-//  *     armor: {
-//  *       "weight": true
-//  *     }
-//  *   }
-//  *
-//  * @param settings
-//  * @returns {Object}
-//  */
-// function setDefaultItemProperties(settings) {
-//   let defaults;
-//   switch (game.system.id) {
-//     case 'dnd5e':
-//       defaults = defaultPropertiesDND5e;
-//       break;
-//     case 'wfrp4e':
-//       defaults = defaultPropertiesWFRP4e;
-//       break;
-//     case 'pf2e':
-//       defaults = defaultPropertiesPF2e;
-//       break;
-//     case 'swade':
-//       defaults = defaultPropertiesSwade;
-//       break;
-//     default:
-//   }
-
-//   if (defaults) {
-//     log(` Loaded Default Properties from ${game.system.id} built-in integration.`);
-//   }
-//   return mergeObject(settings, defaults);
-// }


### PR DESCRIPTION
Then it is clear that @Forien was a dragon with this code because even without the item properties the basic functionalities of the module work with the "generic" case. So to fix the problem [No longer works on PF1E](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-unidentified-items/issues/31) (and also for backward compatibility) i removed the tag system from the `module.json`.

This was a miss from my side sorry @Varriount .

**All the other bugs remain to be fixed ... and the update to fvtt10...**

P.S. @Varriount  i didn't apply the new prettier configuration just to point out that I haven't touched any of the code other than removing some commented code,  If you like, you can apply it before the release


